### PR TITLE
Update `chrome-dev`, `chrome-stable`, enable `allowUnfree` for `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711163522,
-        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
+        "lastModified": 1714076141,
+        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
+        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs { system = "x86_64-linux"; config.allowUnfree = true; };
         google-chrome = channel:
           pkgs.callPackage ./google-chrome { inherit channel; };
       in {

--- a/google-chrome/upstream-info.nix
+++ b/google-chrome/upstream-info.nix
@@ -4,18 +4,18 @@
     version = "125.0.6422.14";
   };
   dev = {
-    hash_deb_amd64 = "sha256-wRjR0Batmjxh3Cmkwsxx0G6c8554bqfRo5GNj7KEZAc=";
-    version = "126.0.6423.2";
+    hash_deb_amd64 = "sha256-a/2+IPm237fH17gUfqpzS0Yf8lkMXj270Ao4Usr0SKo=";
+    version = "126.0.6439.0";
   };
   stable = {
     chromedriver = {
-      hash_darwin = "sha256-wVLNwIlol6rK3Jf+JUNw2vbz/yVVEQ1lmKsCy1gfBvM=";
+      hash_darwin = "sha256-RGOChK4JhrFUgVY/5YqgE0KFLRl6a7X2llw1ZfhiPXY=";
       hash_darwin_aarch64 =
-        "sha256-E6VUi+HAP+eE7OpEI3DrzJ/1hABjIAu4XbXSmlfV7e4=";
-      hash_linux = "sha256-xnCiyNYAwmB2cfz7k4RPQVwcae3QSnVxRBje3yvAhI8=";
-      version = "124.0.6367.78";
+        "sha256-K1jFXmWtXrS43UJg2mQ39Kae6tv7E9Fxm6LUWg+uwLo=";
+      hash_linux = "sha256-xwaRNh7sllyNaq8+aLAZDQ3uDg06cu3KYqc02LWPSyw=";
+      version = "124.0.6367.91";
     };
-    hash_deb_amd64 = "sha256-CpjdZvm7H9Dc2MwvDhvegguG8ym8W2rLfGTUNF/ZoYY=";
-    version = "124.0.6367.78";
+    hash_deb_amd64 = "sha256-CyCbZQ5ce8WLTt2JVSqbDkLDboE4BloiZ8pJff3dmSY=";
+    version = "124.0.6367.91";
   };
 }


### PR DESCRIPTION
## Description of Changes
Updates
- chromeDev: 126.0.6423.2 -> 126.0.6439.0
- chrome: 124.0.6367.78 -> 124.0.6367.91

Allows unfree packages from `nixpkgs`, so we don't have to manually set impure when running the flake.